### PR TITLE
fix debian.sh and cli.sh bugs

### DIFF
--- a/scripts/install/debian.sh
+++ b/scripts/install/debian.sh
@@ -35,7 +35,12 @@ if [ -f /usr/sbin/ufw ];then
 
 fi
 
-ufw disable
+if [ -f /usr/sbin/ufw ];then
+
+	ufw disable
+
+fi
+
 
 if [ ! -f /usr/sbin/ufw ];then
 	apt install -y firewalld

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -297,8 +297,8 @@ if [ "$OSNAME" == "macos" ]; then
 elif [ "$OSNAME" == "ubuntu"  ] || [ "$OSNAME" == "debian" ]; then
     
 
-    aptitude install -y libcurl4-gnutls-dev
-    apt-get install -y devscripts
+    apt install -y libcurl4-gnutls-dev
+    apt install -y devscripts
 
     apt install -y libffi-dev
     apt install -y cmake automake make
@@ -335,7 +335,7 @@ elif [ "$OSNAME" == "ubuntu"  ] || [ "$OSNAME" == "debian" ]; then
     apt install -y libmariadb-dev
     #apt install -y libmysqlclient-dev   
     apt install -y libmariadb-dev-compat
-    apt install -y libmariadbclient-dev 
+    #apt install -y libmariadbclient-dev 
 else
 
     yum install -y openldap openldap-devel libtirpc libtirpc-devel rpcgen


### PR DESCRIPTION
- [debian.sh] 添加了ufw检测判断，防止无效命令
- [cli.sh] aptitude未安装改为apt，apt-get改为apt
- [cli.sh] debain无libmariadbclient-dev，且替代其的libmariadb-dev和libmariadb-dev-compat已有
