### PR TITLE
update authorization for install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,13 +13,18 @@ startTime=`date +%s`
 _os=`uname`
 echo "use system: ${_os}"
 
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root!"
+  exit
+fi
+
 if grep -Eqi "Ubuntu" /etc/issue || grep -Eq "Ubuntu" /etc/*-release; then
-	sudo ln -sf /bin/bash /bin/sh
+	ln -sf /bin/bash /bin/sh
 	#sudo dpkg-reconfigure dash
 fi
 
 if grep -Eqi "Debian" /etc/issue || grep -Eq "Debian" /etc/*-release; then
-	sudo ln -sf /bin/bash /bin/sh
+	ln -sf /bin/bash /bin/sh
 fi
 
 


### PR DESCRIPTION
- [install.sh ] 前置root权限检测，取消sudo命令：debian默认无sudo，且后续安装需要root权限。