### PR TITLE
fix: mkdir redis data dir

### DIFF
--- a/plugins/redis/install.sh
+++ b/plugins/redis/install.sh
@@ -24,6 +24,7 @@ Install_redis()
 	cd $serverPath/source && tar -zxvf redis-${VERSION}.tar.gz
 
 	mkdir -p $serverPath/redis
+	mkdir -p $serverPath/redis/data
 	cd redis-${VERSION} && make PREFIX=$serverPath/redis install
 	sed '/^ *#/d' redis.conf > $serverPath/redis/redis.conf
 


### PR DESCRIPTION
### 合并描述

centos 8 安装 redis 插件后, 启动提示 fail

systemctl stauts redis 提示无法启动

手动启动 `/www/server/redis/bin/redis-server` 并指定配置文件 ` /www/server/redis/redis.conf` 提示 `Can't open the log file: No such file or directory`
