### PR TITLE
修正`MariaDB 10.8`安装后显示为`MariaDB 10.7`的问题

### DIFF
--- a/plugins/mariadb/versions/10.8/install.sh
+++ b/plugins/mariadb/versions/10.8/install.sh
@@ -86,7 +86,7 @@ Install_app()
 		make -j${cpuCore} && make install && make clean
 
 		if [ -d $serverPath/mariadb ];then
-			echo '10.7' > $serverPath/mariadb/version.pl
+			echo '10.8' > $serverPath/mariadb/version.pl
 			echo '安装完成' > $install_tmp
 		else
 			# rm -rf ${mariadbDir}/mariadb-${MY_VER}


### PR DESCRIPTION
### 合并描述

修正`MariaDB 10.8`安装后显示为`MariaDB 10.7`的问题
