### PR TITLE
修正获取证书内反向代理设置检测

### DIFF
--- a/class/core/site_api.py
+++ b/class/core/site_api.py
@@ -633,8 +633,19 @@ class site_api:
             if siteConf.find('301-END') != -1:
                 return mw.returnJson(False, '检测到您的站点做了301重定向设置，请先关闭重定向!')
 
-            if siteConf.find('PROXY-END') != -1:
-                return mw.returnJson(False, '检测到您的站点做了反向代理设置，请先关闭反向代理!')
+            #检测存在反向代理
+            data_path = self.getProxytDataPath(siteName)
+            data_content = mw.readFile(data_path)
+            if data_content != False:
+                try:
+                    data = json.loads(data_content)
+                except:
+                    pass
+                for proxy in data:
+                    proxy_dir = "{}/{}".format(self.proxyPath, siteName)
+                    proxy_dir_file = proxy_dir + '/' + proxy['id'] + '.conf'
+                    if os.path.exists(proxy_dir_file):
+                        return mw.returnJson(False, '检测到您的站点做了反向代理设置，请先关闭反向代理!')
 
         letpath = self.sslDir + siteName
         csrpath = letpath + "/fullchain.pem"  # 生成证书路径


### PR DESCRIPTION
之前判断PROXY-END在关闭反向代理时仍会检测到，必须删除规则。
修改后正常

### 合并描述

- 我添加了测试用例来覆盖新代码。
