### PR TITLE
修复网站统计【初始安装】不可用

### DIFF
--- a/plugins/webstats/index.py
+++ b/plugins/webstats/index.py
@@ -253,7 +253,7 @@ def start():
     if not mw.isAppleSystem():
         mw.execShell("chown -R www:www " + getServerDir())
 
-    mw.opWeb("reload")
+    mw.opWeb("restart")
     return 'ok'
 
 

--- a/plugins/webstats/index.py
+++ b/plugins/webstats/index.py
@@ -253,6 +253,7 @@ def start():
     if not mw.isAppleSystem():
         mw.execShell("chown -R www:www " + getServerDir())
 
+    # issues:326
     mw.opWeb("restart")
     return 'ok'
 


### PR DESCRIPTION
### 合并描述

原来的，重启一下，即可。

- #326 。
- 修复网站统计【初始安装】不可用。
