### PR TITLE
修复op_waf由于类型转换错误导致的500问题

### DIFF
--- a/plugins/op_waf/waf/lua/common.lua
+++ b/plugins/op_waf/waf/lua/common.lua
@@ -644,9 +644,9 @@ function _M.write_log(self, name, rule)
     local ip = params['ip']
     local ngx_time = ngx.time()
     
-    local retry = config['retry']['retry']
-    local retry_time = config['retry']['retry_time']
-    local retry_cycle = config['retry']['retry_cycle']
+    local retry = tonumber(config['retry']['retry'])
+    local retry_time = tonumber(config['retry']['retry_time'])
+    local retry_cycle = tonumber(config['retry']['retry_cycle'])
     
     local count = ngx.shared.waf_drop_ip:get(ip)
     if count then
@@ -662,7 +662,7 @@ function _M.write_log(self, name, rule)
         error_rule = nil
     end
 
-    local count = ngx.shared.waf_drop_ip:get(ip)
+    local count = tonumber(ngx.shared.waf_drop_ip:get(ip))
     -- self:D("write_log; count:" ..tostring(count).. ",retry:" .. tostring(retry) )
     if (count > retry and name ~= 'cc') then
         local safe_count,_ = ngx.shared.waf_drop_sum:get(ip)

--- a/plugins/op_waf/waf/lua/init.lua
+++ b/plugins/op_waf/waf/lua/init.lua
@@ -244,7 +244,7 @@ local function waf_drop_ip()
     local count = ngx.shared.waf_drop_ip:get(ip)
     if not count then return false end
 
-    local retry = config['retry']['retry']
+    local retry = tonumber(config['retry']['retry'])
     -- C:D("waf_drop;count:"..tostring(count)..",retry:"..tostring(retry))
     -- C:D("waf_drop;count > retry:"..tostring(count > retry))
     if count >  retry then


### PR DESCRIPTION
### 合并描述

- Bug 情况
在自定义OP_WAF配置(e.g. 封禁时间)之后，尽管正常拦截恶意请求，但在请求时会出现500错误，且无法完成其它规则(如: 恶意请求次数太多后应当封禁ip)。
(以上原因是推理的, 因为我一开始用op waf就500了哈哈哈哈哈好神奇!)

- 涉及版本
> 1. OP防火墙 0.2.4
> 2. 面板版本 0.12.1-0.12.2 （12.1是我最开始用的, 更新之后才发现没解决)
> 3. 系统 Ubuntu 22.04 LTS
--


- 报错

```
2023/02/12 02:18:22 [error] 3305#0: *20 lua entry thread aborted: runtime error: /www/server/openresty/lualib/resty/core/shdict.lua:196: attempt to compare string with number
stack traceback:
coroutine 0:
	/www/server/openresty/lualib/resty/core/shdict.lua: in function 'set'
	/www/server/op_waf/waf/lua/common.lua:655: in function 'write_log'
	/www/server/op_waf/waf/lua/init.lua:178: in function 'waf_get_args'
	/www/server/op_waf/waf/lua/init.lua:560: in function 'waf'
	/www/server/op_waf/waf/lua/init.lua:574: in main chunk, client: [马赛克],
```
```
2023/02/12 02:27:57 [error] 7629#0: *30 lua entry thread aborted: runtime error: /www/server/op_waf/waf/lua/common.lua:667: attempt to compare string with number
stack traceback:
coroutine 0:
	/www/server/op_waf/waf/lua/common.lua: in function 'write_log'
	/www/server/op_waf/waf/lua/init.lua:178: in function 'waf_get_args'
	/www/server/op_waf/waf/lua/init.lua:560: in function 'waf'
	/www/server/op_waf/waf/lua/init.lua:574: in main chunk, 
```
```
2023/02/12 02:35:18 [error] 10987#0: *11 lua entry thread aborted: runtime error: /www/server/op_waf/waf/lua/init.lua:250: attempt to compare string with number
stack traceback:
coroutine 0:
	/www/server/op_waf/waf/lua/init.lua: in function 'waf_drop_ip'
	/www/server/op_waf/waf/lua/init.lua:546: in function 'waf'
	/www/server/op_waf/waf/lua/init.lua:574: in main chunk
```

- 修补方案
由于不会lua，凭着感觉(?)搜了一下把string转number后问题解决(见pull requests)

当然我这个做法不知道啥时候又会冒bug, 或许可以在写配置那里做好类型转换....吧?
