### PR TITLE
Update __init__.py

### DIFF
--- a/route/__init__.py
+++ b/route/__init__.py
@@ -256,7 +256,7 @@ def webhook():
         'params': request.args.get('params', '').strip()
     }
 
-    if request.method == 'POST':
+    if request.method == 'POST' and request.args.get('post', ''):
         input_args = {
             'access_key': request.form.get('access_key', '').strip(),
             'params': request.form.get('params', '').strip()


### PR DESCRIPTION
解决gogs webhook 钩子 验证失败的问题

不根据http method 来确定接受参数，使用 url 参数post=1来强制使用post


