### PR TITLE
0.16.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ docker run -itd --name mw-server --privileged=true -p 7200:7200 -p 80:80 -p 443:
 ```
 
 
-### 版本更新 0.16.5
+### 版本更新 0.16.6
 
-* 文件管理，增加排序。
+- openresty【1.25.3.1】配置更新，支持h3; 
+- 修复php83的扩展bcmath在centos7安装出错。
 
 ### JSDelivr安装地址
 

--- a/class/core/config_api.py
+++ b/class/core/config_api.py
@@ -28,7 +28,7 @@ from flask import request
 
 class config_api:
 
-    __version = '0.16.5'
+    __version = '0.16.6'
     __api_addr = 'data/api.json'
 
     # 统一默认配置文件

--- a/class/core/site_api.py
+++ b/class/core/site_api.py
@@ -2785,6 +2785,7 @@ location ^~ {from} {\n\
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
+    add_header Strict-Transport-Security "max-age=63072000" always;
     error_page 497  https://$host$request_uri;""" % (certPath, keyPath)
             if(conf.find('ssl_certificate') != -1):
                 return mw.returnData(True, 'SSL开启成功!')

--- a/class/core/site_api.py
+++ b/class/core/site_api.py
@@ -2767,10 +2767,16 @@ location ^~ {from} {\n\
         mw.writeLog('TYPE_SITE', '设置成功,站点到期后将自动停止!', (siteName, edate))
         return mw.returnJson(True, '设置成功,站点到期后将自动停止!')
 
-# ssl相关方法 start
+    # ssl相关方法 start
     def setSslConf(self, siteName):
         file = self.getHostConf(siteName)
         conf = mw.readFile(file)
+
+        version = ''
+        version_file_pl = mw.getServerDir() + '/openresty/version.pl'
+        if os.path.exists(version_file_pl):
+            version = mw.readFile(version_file_pl)
+
 
         keyPath = self.sslDir + '/' + siteName + '/privkey.pem'
         certPath = self.sslDir + '/' + siteName + '/fullchain.pem'
@@ -2799,6 +2805,10 @@ location ^~ {from} {\n\
                 listen = re.search(rep, conf).group()
                 http_ssl = "\n\tlisten 443 ssl http2;"
                 http_ssl = http_ssl + "\n\tlisten [::]:443 ssl http2;"
+
+                if version == '1.25.3.1':
+                    http_ssl = http_ssl + "\n\tlisten 443 quic;"
+
                 conf = conf.replace(listen, listen + http_ssl)
 
             mw.backFile(file)

--- a/class/core/site_api.py
+++ b/class/core/site_api.py
@@ -2787,7 +2787,7 @@ location ^~ {from} {\n\
 
                 http3Header = """
     add_header Strict-Transport-Security "max-age=63072000";
-    add_header Alt-Svc 'h3=":443"; ma=2592000';
+    add_header Alt-Svc 'h3=":443";ma=86400,h3-29=":443";ma=86400';
 """
                 if version != '1.25.3.1':
                     http3Header = '';

--- a/class/core/site_api.py
+++ b/class/core/site_api.py
@@ -2784,6 +2784,14 @@ location ^~ {from} {\n\
         if conf:
             if conf.find('ssl_certificate') == -1:
                 #ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:HIGH:!aNULL:!MD5:!RC4:!DHE;
+
+                http3Header = """
+    add_header Strict-Transport-Security "max-age=63072000";
+    add_header Alt-Svc 'h3=":443"; ma=2592000';
+"""
+                if version != '1.25.3.1':
+                    http3Header = '';
+
                 sslStr = """#error_page 404/404.html;
     ssl_certificate    %s;
     ssl_certificate_key  %s;
@@ -2792,9 +2800,8 @@ location ^~ {from} {\n\
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
-    add_header Strict-Transport-Security "max-age=63072000";
-    add_header Alt-Svc 'h3=":443"; ma=2592000';
-    error_page 497  https://$host$request_uri;""" % (certPath, keyPath)
+    %s
+    error_page 497  https://$host$request_uri;""" % (certPath, keyPath, http3Header)
             if(conf.find('ssl_certificate') != -1):
                 return mw.returnData(True, 'SSL开启成功!')
 

--- a/class/core/site_api.py
+++ b/class/core/site_api.py
@@ -2785,7 +2785,8 @@ location ^~ {from} {\n\
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
-    add_header Strict-Transport-Security "max-age=63072000" always;
+    add_header Strict-Transport-Security "max-age=63072000";
+    add_header Alt-Svc 'h3=":443"; ma=2592000';
     error_page 497  https://$host$request_uri;""" % (certPath, keyPath)
             if(conf.find('ssl_certificate') != -1):
                 return mw.returnData(True, 'SSL开启成功!')

--- a/class/core/site_api.py
+++ b/class/core/site_api.py
@@ -2776,6 +2776,7 @@ location ^~ {from} {\n\
         version_file_pl = mw.getServerDir() + '/openresty/version.pl'
         if os.path.exists(version_file_pl):
             version = mw.readFile(version_file_pl)
+            version = version.strip()
 
 
         keyPath = self.sslDir + '/' + siteName + '/privkey.pem'

--- a/class/core/site_api.py
+++ b/class/core/site_api.py
@@ -2776,11 +2776,12 @@ location ^~ {from} {\n\
         certPath = self.sslDir + '/' + siteName + '/fullchain.pem'
         if conf:
             if conf.find('ssl_certificate') == -1:
+                #ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:HIGH:!aNULL:!MD5:!RC4:!DHE;
                 sslStr = """#error_page 404/404.html;
     ssl_certificate    %s;
     ssl_certificate_key  %s;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:HIGH:!aNULL:!MD5:!RC4:!DHE;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;

--- a/data/sql/default.sql
+++ b/data/sql/default.sql
@@ -49,7 +49,7 @@ ALTER TABLE `firewall` ADD COLUMN `protocol` TEXT DEFAULT 'tcp';
 
 INSERT INTO `firewall` (`id`, `port`, `protocol`, `ps`, `addtime`) VALUES
 (1, '80',  'tcp','网站默认端口', '0000-00-00 00:00:00'),
-(2, '443', 'tcp', 'HTTPS', '0000-00-00 00:00:00');
+(2, '443', 'tcp/udp', 'HTTPS', '0000-00-00 00:00:00');
 
 
 

--- a/plugins/openresty/install.sh
+++ b/plugins/openresty/install.sh
@@ -91,6 +91,7 @@ Install_openresty()
 
 
 	opensslVersion="1.1.1p"
+	libresslVersion="1.1.1p"
 	pcreVersion='8.38'
 	if [ "$sysName" == "Darwin" ];then
 
@@ -123,6 +124,16 @@ Install_openresty()
 		if [ "$VERSION" == "1.25.3.1" ]; then
 			OPTIONS="${OPTIONS} --with-http_v3_module"
 
+			
+
+			if [ ! -f ${openrestyDir}/libressl-${libresslVersion}.tar.gz ];then
+		        wget --no-check-certificate -O ${openrestyDir}/libressl-${libresslVersion}.tar.gz https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${libresslVersion}.tar.gz
+		    fi
+
+		    if [ ! -d ${openrestyDir}/libressl-${libresslVersion} ];then
+				cd ${openrestyDir} &&  tar -zxvf libressl-${libresslVersion}.tar.gz
+			fi
+
 			if [ ! -f ${openrestyDir}/openssl-${opensslVersion}.tar.gz ];then
 		        wget --no-check-certificate -O ${openrestyDir}/openssl-${opensslVersion}.tar.gz https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz
 		    fi
@@ -130,7 +141,13 @@ Install_openresty()
 		    if [ ! -d ${openrestyDir}/openssl-${opensslVersion} ];then
 				cd ${openrestyDir} &&  tar -zxvf openssl-${opensslVersion}.tar.gz
 			fi
-		    OPTIONS="${OPTIONS} --with-openssl=${openrestyDir}/openssl-${opensslVersion}"
+
+		    # OPTIONS="${OPTIONS} --with-openssl=${openrestyDir}/openssl-${opensslVersion}"
+		    OPTIONS="${OPTIONS} --with-cc-opt=-I${openrestyDir}-${libresslVersion}/libressl/build/include"
+		    OPTIONS="${OPTIONS} --with-cc-opt=-I${openrestyDir}-${libresslVersion}/libressl/build/lib"
+
+		    # --with-cc-opt="-I../libressl/build/include"
+    		# --with-ld-opt="-L../libressl/build/lib"
 		fi
 	fi
 

--- a/plugins/openresty/install.sh
+++ b/plugins/openresty/install.sh
@@ -91,7 +91,7 @@ Install_openresty()
 
 
 	opensslVersion="1.1.1p"
-	libresslVersion="1.1.1p"
+	libresslVersion="3.9.1"
 	pcreVersion='8.38'
 	if [ "$sysName" == "Darwin" ];then
 

--- a/plugins/openresty/install.sh
+++ b/plugins/openresty/install.sh
@@ -143,8 +143,8 @@ Install_openresty()
 			fi
 
 		    # OPTIONS="${OPTIONS} --with-openssl=${openrestyDir}/openssl-${opensslVersion}"
-		    OPTIONS="${OPTIONS} --with-cc-opt=-I${openrestyDir}-${libresslVersion}/libressl/build/include"
-		    OPTIONS="${OPTIONS} --with-cc-opt=-I${openrestyDir}-${libresslVersion}/libressl/build/lib"
+		    OPTIONS="${OPTIONS} --with-cc-opt=-I${openrestyDir}/libressl-${libresslVersion}/libressl/build/include"
+		    OPTIONS="${OPTIONS} --with-cc-opt=-I${openrestyDir}/libressl-${libresslVersion}/libressl/build/lib"
 
 		    # --with-cc-opt="-I../libressl/build/include"
     		# --with-ld-opt="-L../libressl/build/lib"

--- a/plugins/openresty/install.sh
+++ b/plugins/openresty/install.sh
@@ -119,12 +119,20 @@ Install_openresty()
 		# brew info openssl@1.1 | grep /opt/homebrew/Cellar/openssl@1.1 | cut -d \  -f 1 | awk 'END {print}'
 		# OPENSSL_LIB_DEPEND_DIR=`brew info openssl@1.1 | grep ${BREW_DIR}/Cellar/openssl@1.1 | cut -d \  -f 1 | awk 'END {print}'`
 		# OPTIONS="${OPTIONS} --with-openssl=${OPENSSL_LIB_DEPEND_DIR}"
-	fi
+	else
+		if [ "$VERSION" == "1.25.3.1" ]; then
+			OPTIONS="${OPTIONS} --with-http_v3_module"
 
-	if [ "$VERSION" == "1.25.3.1" ]; then
-		OPTIONS="${OPTIONS} --with-http_v3_module"
-	fi
+			if [ ! -f ${openrestyDir}/openssl-${opensslVersion}.tar.gz ];then
+		        wget --no-check-certificate -O ${openrestyDir}/openssl-${opensslVersion}.tar.gz https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz
+		    fi
 
+		    if [ ! -d ${openrestyDir}/openssl-${opensslVersion} ];then
+				cd ${openrestyDir} &&  tar -zxvf openssl-${opensslVersion}.tar.gz
+			fi
+		    OPTIONS="${OPTIONS} --with-openssl=${openrestyDir}/openssl-${opensslVersion}"
+		fi
+	fi
 
 
 	# --with-openssl=$serverPath/source/lib/openssl-1.0.2q

--- a/plugins/openresty/install.sh
+++ b/plugins/openresty/install.sh
@@ -193,6 +193,10 @@ Install_openresty()
     if [ -d ${openrestyDir}/openssl-${opensslVersion} ];then
     	rm -rf ${openrestyDir}/openssl-${opensslVersion}
     fi
+
+    if [ -d ${openrestyDir}/libressl-${libresslVersion} ];then
+    	rm -rf ${openrestyDir}/libressl-${libresslVersion}
+    fi
 	echo '安装完成'
 }
 

--- a/plugins/openresty/install.sh
+++ b/plugins/openresty/install.sh
@@ -142,7 +142,7 @@ Install_openresty()
 				cd ${openrestyDir} &&  tar -zxvf openssl-${opensslVersion}.tar.gz
 			fi
 
-		    # OPTIONS="${OPTIONS} --with-openssl=${openrestyDir}/openssl-${opensslVersion}"
+		    OPTIONS="${OPTIONS} --with-openssl=${openrestyDir}/openssl-${opensslVersion}"
 		    OPTIONS="${OPTIONS} --with-cc-opt=-I${openrestyDir}/libressl-${libresslVersion}/libressl/build/include"
 		    OPTIONS="${OPTIONS} --with-cc-opt=-I${openrestyDir}/libressl-${libresslVersion}/libressl/build/lib"
 

--- a/plugins/php/versions/common/bcmath.sh
+++ b/plugins/php/versions/common/bcmath.sh
@@ -60,8 +60,13 @@ Install_lib()
 		fi
 
 		$serverPath/php/$version/bin/phpize
-		./configure --with-php-config=$serverPath/php/$version/bin/php-config $OPTIONS
 
+		if [ "$version" == "83" ];then
+			CFLAGS="-std=c99" ./configure --with-php-config=$serverPath/php/$version/bin/php-config $OPTIONS
+		else
+			./configure --with-php-config=$serverPath/php/$version/bin/php-config $OPTIONS
+		fi
+		
 		make clean && make && make install && make clean
 		
 		if [ -d $sourcePath/php${version} ];then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools>=33.1.1
 Werkzeug>=1.0.1,<3.0.0
 wheel>=0.37.1
-gunicorn==20.1.0
+gunicorn>=21.2.0
 requests>=2.27.1
 urllib3>=1.21.1
 flask>=2.0.3,<3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools>=33.1.1
 Werkzeug>=1.0.1,<3.0.0
 wheel>=0.37.1
-gunicorn>=21.2.0
+gunicorn==20.1.0
 requests>=2.27.1
 urllib3>=1.21.1
 flask>=2.0.3,<3.0.0

--- a/scripts/install/alma.sh
+++ b/scripts/install/alma.sh
@@ -53,6 +53,7 @@ if [ ! -f /usr/sbin/iptables ];then
 
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 
 	sed -i 's#AllowZoneDrifting=yes#AllowZoneDrifting=no#g' /etc/firewalld/firewalld.conf

--- a/scripts/install/amazon.sh
+++ b/scripts/install/amazon.sh
@@ -62,6 +62,7 @@ if [ ! -f /usr/sbin/firewalld ];then
 
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 
 	sed -i 's#AllowZoneDrifting=yes#AllowZoneDrifting=no#g' /etc/firewalld/firewalld.conf

--- a/scripts/install/arch.sh
+++ b/scripts/install/arch.sh
@@ -94,6 +94,7 @@ if [ ! -f /usr/sbin/firewalld ];then
 	
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 
 	sed -i 's#AllowZoneDrifting=yes#AllowZoneDrifting=no#g' /etc/firewalld/firewalld.conf

--- a/scripts/install/centos.sh
+++ b/scripts/install/centos.sh
@@ -66,6 +66,7 @@ if [ ! -f /usr/sbin/firewalld ];then
 	
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 
 

--- a/scripts/install/debian.sh
+++ b/scripts/install/debian.sh
@@ -92,6 +92,7 @@ if [ ! -f /usr/sbin/ufw ];then
 	fi
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 
 	systemctl start firewalld

--- a/scripts/install/euler.sh
+++ b/scripts/install/euler.sh
@@ -65,6 +65,7 @@ if [ ! -f /usr/sbin/firewalld ];then
 
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 
 

--- a/scripts/install/fedora.sh
+++ b/scripts/install/fedora.sh
@@ -58,6 +58,7 @@ if [ ! -f /usr/sbin/iptables ];then
 	
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 	firewall-cmd --reload
 fi

--- a/scripts/install/opensuse.sh
+++ b/scripts/install/opensuse.sh
@@ -74,6 +74,7 @@ if [ ! -f /usr/sbin/firewalld ];then
 	
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 
 	sed -i 's#AllowZoneDrifting=yes#AllowZoneDrifting=no#g' /etc/firewalld/firewalld.conf

--- a/scripts/install/rhel.sh
+++ b/scripts/install/rhel.sh
@@ -125,6 +125,7 @@ if [ -f /usr/sbin/firewalld ];then
     fi
     firewall-cmd --permanent --zone=public --add-port=80/tcp
     firewall-cmd --permanent --zone=public --add-port=443/tcp
+    firewall-cmd --permanent --zone=public --add-port=443/udp
     # firewall-cmd --permanent --zone=public --add-port=888/tcp
     # firewall-cmd --permanent --zone=public --add-port=7200/tcp
     # firewall-cmd --permanent --zone=public --add-port=3306/tcp

--- a/scripts/install/rocky.sh
+++ b/scripts/install/rocky.sh
@@ -49,6 +49,7 @@ if [ ! -f /usr/sbin/iptables ];then
 	firewall-cmd --permanent --zone=public --add-port=22/tcp
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 	# firewall-cmd --permanent --zone=public --add-port=7200/tcp
 	# firewall-cmd --permanent --zone=public --add-port=3306/tcp

--- a/scripts/install/ubuntu.sh
+++ b/scripts/install/ubuntu.sh
@@ -62,6 +62,7 @@ if [ ! -f /usr/sbin/ufw ];then
 
 	firewall-cmd --permanent --zone=public --add-port=80/tcp
 	firewall-cmd --permanent --zone=public --add-port=443/tcp
+	firewall-cmd --permanent --zone=public --add-port=443/udp
 	# firewall-cmd --permanent --zone=public --add-port=888/tcp
 
 	systemctl start firewalld


### PR DESCRIPTION
### 合并描述

在网站开启SSL，会自动配置好。
但是依然要注意:
1.检查端口443的udp端口是否开启。(在本面板中，之前版本中没有开启。 现在安装443的tcp/udp都默认放开)
2.使用云服务器，也要注意以上问题。

检查http3是否开启
*  https://http3check.net/

- openresty【1.25.3.1】配置更新，支持h3; 
- 修复php83的扩展bcmath在centos7安装出错。
