### PR TITLE
修复数据类型错误导致的openresty lua error 从而使得useragent匹配失效的bug

### DIFF
--- a/plugins/op_waf/index.py
+++ b/plugins/op_waf/index.py
@@ -971,9 +971,14 @@ def setRetry():
     conf = getJsonPath('config')
     content = mw.readFile(conf)
     cobj = json.loads(content)
-
-    cobj['retry'] = args
-
+    
+    ## 修复数据类型错误
+    tmp = args
+    tmp['cycle'] = int(tmp['retry'])
+    tmp['limit'] = int(tmp['retry_time'])
+    tmp['endtime'] = int(tmp['retry_cycle'])
+    
+    cobj['retry'] = tmp
     cjson = mw.getJson(cobj)
     mw.writeFile(conf, cjson)
 


### PR DESCRIPTION
### 合并描述

现有的代码在后台保存"恶意容忍度"规则后，会出现useragent不能匹配的bug，经过调试发现原因为python处理前端提交的json数据有些没有转成int，故修改此代码，请求合并
