### PR TITLE
修复提交正则过滤时，因为正则中存在冒号，错误的将所有的冒号用于分割，应该只使用第一个冒号分割

### DIFF
--- a/plugins/op_waf/index.py
+++ b/plugins/op_waf/index.py
@@ -40,11 +40,11 @@ def getArgs():
 
     if args_len == 1:
         t = args[0].strip('{').strip('}')
-        t = t.split(':')
+        t = t.split(':', 1)
         tmp[t[0]] = t[1]
     elif args_len > 1:
         for i in range(len(args)):
-            t = args[i].split(':')
+            t = args[i].split(':', 1)
             tmp[t[0]] = t[1]
 
     return tmp

--- a/plugins/op_waf/waf/rule/user_agent.json
+++ b/plugins/op_waf/waf/rule/user_agent.json
@@ -2,5 +2,7 @@
 	[1,"(HTTrack|Apache-HttpClient|harvest|audit|dirbuster|pangolin|nmap|sqln|hydra|Parser|libwww|BBBike|sqlmap|w3af|owasp|Nikto|fimap|havij|zmeu|BabyKrokodil|netsparker|httperf| SF/)","关键词过滤1",0],
 	[1,"(ApacheBench)","AB测试",0],
 	[1,"(Amazonbot)","Amazon爬虫",0],
-	[1,"(SemrushBot)","Semrush爬虫",0]
+	[1,"(SemrushBot)","Semrush爬虫",0],
+	[1,"(^$|Apache-HttpClient|colly|curl|okhttp|Go-http-client|python-requests|Python-urllib|python-httpx|Scrapy|aiohttp|Nmap Scripting Engine|Java|fasthttp|Wget)","非法脚本",0],
+	[1,"(CensysInspect|intelx\\.io_bot|InternetMeasurement|ips-agent|MJ12Bot|NetcraftSurveyAgent|SemrushBot|l9scan|SEOlyt|kirkland-signature|ZoominfoBot|Expanse|CheckMarkNetwork|dotbot|Pandalytics|Screaming Frog SEO Spider|W3C_CSS_Validator_JFouffa)","非法扫描器",0]
 ]


### PR DESCRIPTION
编辑waf规则时，使用正则表达式中如果存在冒号，但def getArgs()函数会使用冒号分隔，这会造成正则表达式中的冒号也被用于分隔，从而造成保存后正则表达式不全的bug。这个pull request，添加了split(":" ,1)参数，使得python只通过第一个冒号分隔键值对，故修复了此bug