### PR TITLE
修复http3在多Worker 下需要reuseport以及不传HOST变量的问题

### DIFF
--- a/class/core/site_api.py
+++ b/class/core/site_api.py
@@ -2828,8 +2828,8 @@ location ^~ {from} {\n\
                 if version.startswith('1.25'):
                     http_ssl = "\n\tlisten 443 ssl;"
                     http_ssl = http_ssl + "\n\tlisten [::]:443 ssl;"
-                    http_ssl = http_ssl + "\n\tlisten 443 quic;"
-                    http_ssl = http_ssl + "\n\tlisten [::]:443 quic;"
+                    http_ssl = http_ssl + "\n\tlisten 443 quic reuseport;"
+                    http_ssl = http_ssl + "\n\tlisten [::]:443 quic reuseport;"
                     http_ssl = http_ssl + "\n\thttp2 on;"
                 else:
                     http_ssl = "\n\tlisten 443 ssl http2;"

--- a/plugins/php/conf/pathinfo.conf
+++ b/plugins/php/conf/pathinfo.conf
@@ -6,3 +6,6 @@ if ($fastcgi_script_name ~ "^(.+?\.php)(/.+)$") {
 fastcgi_param SCRIPT_FILENAME $document_root$real_script_name;
 fastcgi_param SCRIPT_NAME $real_script_name;
 fastcgi_param PATH_INFO $path_info;
+
+#修复http3不传HOST问题
+fastcgi_param HTTP_HOST $host;


### PR DESCRIPTION
修复http3在多Worker 下需要reuseport，和不传HOST变量的问题
详见https://talk.plesk.com/threads/nginx-http3-with-multiple-workers.374696/
https://wordpress.org/support/topic/undefined-array-key-http_host-when-http-3-is-enabled/