### PR TITLE
Fix: Unable to move

### DIFF
--- a/scripts/old/install.sh
+++ b/scripts/old/install.sh
@@ -101,7 +101,7 @@ if [ $OSNAME != "macos" ];then
 		if [ "$LOCAL_ADDR" == "common" ];then
 			curl --insecure -sSLo /tmp/master.zip ${HTTP_PREFIX}github.com/midoks/mdserver-web/archive/refs/tags/${VERSION}.zip
 			cd /tmp && unzip /tmp/master.zip
-			mv -f /tmp/mdserver-web-master /www/server/mdserver-web
+			mv -f /tmp/mdserver-web-${VERSION} /www/server/mdserver-web
 			rm -rf /tmp/master.zip
 			rm -rf /tmp/mdserver-web-master
 		else


### PR DESCRIPTION
Fix: Cannot install old version of mdserver because of the wrong path

旧版安装
```
curl --insecure -fsSL  https://raw.githubusercontent.com/midoks/mdserver-web/dev/scripts/old/install.sh | bash
curl --insecure -fsSL  https://raw.githubusercontent.com/midoks/mdserver-web/dev/scripts/old/update.sh | bash
```