### PR TITLE
fix: rename cron_name to cron_shell

### DIFF
--- a/web/utils/crontab.py
+++ b/web/utils/crontab.py
@@ -159,7 +159,7 @@ class crontab(object):
         cron_path = mw.getServerDir() + '/cron'
         cron_shell = self.getShell(data)
 
-        cmd += ' ' + cron_path + '/' + cron_name + ' >> ' + cron_path + '/' + cron_name + '.log 2>&1'
+        cmd += ' ' + cron_path + '/' + cron_shell + ' >> ' + cron_path + '/' + cron_shell + '.log 2>&1'
 
         if not mw.isAppleSystem():
             sh_data = self.writeShell(cmd)


### PR DESCRIPTION
### 合并描述

- 修复了在添加计划任务时由于变量未初始化产生的错误
![image](https://github.com/user-attachments/assets/9da5c2f2-23c5-41a7-b6a4-41d66dcf3e73)
