### PR TITLE
openresty 1.29.2.4

### DIFF
--- a/plugins/openresty/versions/1.29.2/install.sh
+++ b/plugins/openresty/versions/1.29.2/install.sh
@@ -14,7 +14,7 @@ sysName=`uname`
 action=$1
 type=$2
 
-VERSION=1.29.2.3
+VERSION=1.29.2.4
 
 openrestyDir=${serverPath}/source/openresty
 


### PR DESCRIPTION
移植 [nginx](https://nginx.org/en/security_advisories.html) 的漏洞补丁
[CVE-2026-42945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-42945): Buffer overflow in the ngx_http_rewrite_module
[CVE-2026-42946](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-42946): Buffer overread in the ngx_http_scgi_module and ngx_http_uwsgi_module
[CVE-2026-42934](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-42934): Buffer overread in the ngx_http_charset_module
[CVE-2026-40460](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-40460): HTTP/3 address spoofing
[CVE-2026-40701](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-40701): resolver use-after-free in OCSP