### PR TITLE
Fix return statement for unban IP function

### DIFF
--- a/plugins/fail2ban/index.py
+++ b/plugins/fail2ban/index.py
@@ -328,7 +328,7 @@ def setBlackIp():
                 mw.execShell('fail2ban-client -vvv set {jail} unbanip {ip}'.format(jail=d, ip=ip))
 
         mw.writeFile(getBlackFile(), json.dumps([]))
-        return nw.returnJson(True, "禁止IP成功")
+        return mw.returnJson(True, "禁止IP成功")
 
     # 检查IP格式
     for ip in add_ip_list:


### PR DESCRIPTION
### 合并描述

修复了fail2ban插件的两个小bug

一是`mw`被误写为`nw`

二是手动添加fail2ban ip黑名单时（比如`1.2.3.4`）程序会报错`{"status": false, "msg": "IP格式错误 1"}`，原因在于`getArgs()`将`black_ip`解析为字符串，`setBlackIp()`却使用了列表遍历

同时优化了`new_ip_list`判空逻辑
